### PR TITLE
avoid send undefined kid to getPublicKey

### DIFF
--- a/src/verify.ts
+++ b/src/verify.ts
@@ -61,8 +61,9 @@ export function verify(token: string, options: VerifyOptions) {
   try {
     decoded = jwt.decode(token, { complete: true, json: true });
     kid = decoded.header.kid;
-    if (kid === undefined || !kid ) {
-      throw new Error('invalid token');
+
+    if (!kid ) {
+      throw new Error('kid missing from token header');
     }
   } catch (error) {
     return Promise.reject('invalid token');


### PR DESCRIPTION
when you send a non jwks token in verify function the promise never rejects due to a undefined kid is not handled in getPublicKey try catch block.

## Description

avoid a DDos Attack with invalid tokens

Todo

## Checklist

Please ensure your pull request fulfills the following requirements:

- [ ] The commit messages follow our guidelines ([CONTRIBUTING.md](./CONTRIBUTING.md)).
- [ ] Tests for any changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

## Type

bug fix 


