### PR TITLE
Fixes #60 and #63

### DIFF
--- a/src/verify.ts
+++ b/src/verify.ts
@@ -1,9 +1,11 @@
-import { decode as jwtDecode, verify as jwtVerify } from 'jsonwebtoken';
+import jsonwebtoken from 'jsonwebtoken';
 import fetch from 'node-fetch';
 import getPem from 'rsa-pem-from-mod-exp';
 
 import { getItem, setDeferredItem, setItem } from './cache.js';
 import { AzureJwks, VerifyOptions } from './interfaces.js';
+
+const { decode: jwtDecode, verify: jwtVerify } = jsonwebtoken;
 
 /**
  * Get public key.


### PR DESCRIPTION
## Description

This fixes the import issue described in issues #60 and #63. The `jsonwebtoken` package does not export the named values `decode` and `verify` as ES6 exports--it exports them for CommonJS. This allows us to import the packages named exports by using object destructuring on the imported module.

## Checklist

Please ensure your pull request fulfills the following requirements:

- [ N/A ] The commit messages follow our guidelines ([CONTRIBUTING.md](./CONTRIBUTING.md)).
- [ x ] Tests for any changes have been added (for bug fixes / features).
- [ x ] Docs have been added / updated (for bug fixes / features).

## Type

What kind of change does this pull request introduce?

```
[ x ] Bug.
[ ] Feature.
[ ] Code style update (formatting, local variables).
[ ] Refactoring (no functional changes, no api changes).
[ ] Build related changes.
[ ] CI related changes.
[ ] Documentation content changes.
[ ] Other (please describe below).
```

## Breaking Changes

Does this pull request introduce any breaking changes?

```
[ ] Yes
[ x ] No
```

## Other Information

N/A
